### PR TITLE
Encode smiles

### DIFF
--- a/model/framework/code/gdbmedchem_ecfp.py
+++ b/model/framework/code/gdbmedchem_ecfp.py
@@ -2,6 +2,7 @@ from bs4 import BeautifulSoup
 import requests
 import csv
 import sys
+import urllib
 
 # Input Parameters
 input_file = open(sys.argv[1], 'r')
@@ -13,7 +14,8 @@ nnc    = '100'
 data = []
 for input_smiles in Lines:
     input_smiles = input_smiles.strip() 
-    url = 'https://gdb-medchem-simsearch.gdb.tools/search?smi=' + input_smiles +  '&fp=' + fp + '&db=' + db + '&nnc=' + nnc
+    url_encoded_smiles = urllib.parse.quote(input_smiles)
+    url = 'https://gdb-medchem-simsearch.gdb.tools/search?smi=' + url_encoded_smiles +  '&fp=' + fp + '&db=' + db + '&nnc=' + nnc
     r = requests.get(url)
     soup = BeautifulSoup(r.text, features = 'html.parser')
     results = soup.find_all('script')


### PR DESCRIPTION
Hi @GemmaTuron,
As communicated, I modified the `model/framework/code/gdbmedchem_ecfp.py` file. 
Added `import urllib`  at the top, and changed;
`url = 'https://gdb-medchem-simsearch.gdb.tools/search?smi=' + input_smiles + '&fp=' + fp + '&db=' + db + '&nnc=' + nnc`
to
```
    url_encoded_smiles = urllib.parse.quote(input_smiles)
    url = 'https://gdb-medchem-simsearch.gdb.tools/search?smi=' + url_encoded_smiles +  '&fp=' + fp + '&db=' + db + '&nnc=' + nnc
```
The smiles that were [not working before](https://github.com/ersilia-os/eos7jlv/issues/1#issuecomment-1660206051) now work, for example `N#Cc1ccc(-c2nnc3cccc(C(=O)Nc4ccnc(C(F)(F)F)c4)n23)cc1` at line7: [eos7jlv_cli_output2.csv](https://github.com/ersilia-os/eos7jlv/files/12238899/eos7jlv_cli_output2.csv)

Thank you!